### PR TITLE
Fix typo in CSS selector (used in javascript)

### DIFF
--- a/static/movement.js
+++ b/static/movement.js
@@ -3,7 +3,7 @@ $(document).ready( function() {
 	$("#push_notification").click(function(event) {
 		event.preventDefault();
 		if (confirm("Are you sure you want to send this push notification?") == true) {
-			$("input[name='_send_push'").val('1');
+			$("input[name='_send_push']").val('1');
 			$("form.update").submit();
 		}
 	});


### PR DESCRIPTION
Turns out that Chrome handled this just fine - Safari was barfing on it
(hence it not working on my phone! :) )